### PR TITLE
[doc] fix sphinx documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,27 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+project = 'LiteMultiAgent'
+copyright = '2024, Danqing (Danni) Zhang, Balaji Rama, Shiying He, Jingyi Ni'
+author = 'Danqing (Danni) Zhang, Balaji Rama, Shiying He, Jingyi Ni'
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = []
+
+templates_path = ['_templates']
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = 'alabaster'
+html_static_path = ['_static']

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,1 @@
+Just a placeholder

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,1 +1,20 @@
-Just a placeholder
+.. LiteMultiAgent documentation master file, created by
+   sphinx-quickstart on Wed Jul 31 20:12:02 2024.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to LiteMultiAgent's documentation!
+==========================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`


### PR DESCRIPTION
ran the `sphinx-quickstart` script to generate an initial doc hosted at https://litemultiagent.readthedocs.io/en/latest/